### PR TITLE
Implement solution to homework

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const Promise = require('bluebird')
 const getTopPackagesMetadata = require('./util/topPackagesMetadata')
 const getTarballUrls = require('./util/tarballUrls')
 const handleTars = require('./util/handleTars')
@@ -14,8 +13,7 @@ function downloadPackages (count, callback) {
   getTopPackagesMetadata(count)
     .then(getTarballUrls)
     .then(handleTars)
-    .then(() => callback() )
-    .then(() => console.log("All done."))
+    .then(() => callback())
+    .then(() => console.log('All done.'))
     .catch((error) => console.log(error))
-
 }

--- a/index.js
+++ b/index.js
@@ -3,12 +3,11 @@
 const getTopPackagesMetadata = require('./util/topPackagesMetadata')
 const getTarballUrls = require('./util/tarballUrls')
 const handleTars = require('./util/handleTars')
-const COUNT = parseInt(process.env.COUNT, 10) || 10
 
 module.exports = downloadPackages
 
 function downloadPackages (count, callback) {
-  console.log(`Beginning download of top ${COUNT} packages...`)
+  console.log(`Beginning download of top ${count} packages...`)
 
   getTopPackagesMetadata(count)
     .then(getTarballUrls)

--- a/index.js
+++ b/index.js
@@ -15,6 +15,6 @@ function downloadPackages (count) {
     .then(getTarballUrls)
     .then(handleTars)
     .catch((error) => console.log(error))
-    }
+}
 
 downloadPackages(COUNT)

--- a/index.js
+++ b/index.js
@@ -8,13 +8,14 @@ const COUNT = parseInt(process.env.COUNT, 10) || 10
 
 module.exports = downloadPackages
 
-function downloadPackages (count) {
+function downloadPackages (count, callback) {
   console.log(`Beginning download of top ${COUNT} packages...`)
 
   getTopPackagesMetadata(count)
     .then(getTarballUrls)
     .then(handleTars)
+    .then(() => callback() )
+    .then(() => console.log("All done."))
     .catch((error) => console.log(error))
-}
 
-downloadPackages(COUNT)
+}

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const utils = require ('./util')
+const utils = require('./util')
 
 module.exports = downloadPackages
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,12 @@ const utils = require('./util')
 module.exports = downloadPackages
 
 function downloadPackages (count, callback) {
-  console.log(`Beginning download of top ${count} packages...`)
+  if (count > 36) {
+    console.log('!!! The current implementation can only grab up to the 36th most depended-upon package!\n' +
+                '!!! Grabbing the top 36 instead.')
+  } else {
+    console.log(`Beginning download of top ${count} packages...`)
+  }
 
   utils.getTopPackagesMetadata(count)
     .then(utils.getTarballUrls)

--- a/index.js
+++ b/index.js
@@ -1,17 +1,15 @@
 'use strict'
 
-const getTopPackagesMetadata = require('./util/topPackagesMetadata')
-const getTarballUrls = require('./util/tarballUrls')
-const handleTars = require('./util/handleTars')
+const utils = require ('./util')
 
 module.exports = downloadPackages
 
 function downloadPackages (count, callback) {
   console.log(`Beginning download of top ${count} packages...`)
 
-  getTopPackagesMetadata(count)
-    .then(getTarballUrls)
-    .then(handleTars)
+  utils.getTopPackagesMetadata(count)
+    .then(utils.getTarballUrls)
+    .then(utils.handleTars)
     .then(() => callback())
     .then(() => console.log('All done.'))
     .catch((error) => console.log(error))

--- a/index.js
+++ b/index.js
@@ -1,7 +1,26 @@
 'use strict'
 
+const getTopPackagesMetadata = require('./util/topPackagesMetadata.js')
+const getTarballUrls = require('./util/tarballUrls.js')
+const handleTars = require('./util/handleTars.js')
+const COUNT = parseInt(process.env.COUNT, 10) || 10
+
 module.exports = downloadPackages
 
 function downloadPackages (count, callback) {
+  console.log(`Beginning download of top ${COUNT} packages...`)
 
+  getTopPackagesMetadata(count, function (list) {
+    getTarballUrls(list, function (urls) {
+      handleTars(urls, function (error, result) {
+        if (error) console.log(error)
+        else callback(console.log(result))
+      })
+    })
+  })
 }
+
+downloadPackages(COUNT, function (error, result) {
+  if (error) console.log(error)
+  else console.log(result)
+})

--- a/index.js
+++ b/index.js
@@ -1,26 +1,20 @@
 'use strict'
 
-const getTopPackagesMetadata = require('./util/topPackagesMetadata.js')
-const getTarballUrls = require('./util/tarballUrls.js')
-const handleTars = require('./util/handleTars.js')
+const Promise = require('bluebird')
+const getTopPackagesMetadata = require('./util/topPackagesMetadata')
+const getTarballUrls = require('./util/tarballUrls')
+const handleTars = require('./util/handleTars')
 const COUNT = parseInt(process.env.COUNT, 10) || 10
 
 module.exports = downloadPackages
 
-function downloadPackages (count, callback) {
+function downloadPackages (count) {
   console.log(`Beginning download of top ${COUNT} packages...`)
 
-  getTopPackagesMetadata(count, function (list) {
-    getTarballUrls(list, function (urls) {
-      handleTars(urls, function (error, result) {
-        if (error) console.log(error)
-        else callback(console.log(result))
-      })
-    })
-  })
-}
+  getTopPackagesMetadata(count)
+    .then(getTarballUrls)
+    .then(handleTars)
+    .catch((error) => console.log(error))
+    }
 
-downloadPackages(COUNT, function (error, result) {
-  if (error) console.log(error)
-  else console.log(result)
-})
+downloadPackages(COUNT)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "scripts": {
-    "test": "node test.js"
+    "test": "node test.js",
+    "start": "node index.js"
   },
   "dependencies": {
     "request": "~2.81.0",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
     "test": "node test.js"
   },
   "dependencies": {
-    "lodash": "~4.17.4",
     "request": "~2.81.0",
-    "async": "~2.2.0",
+    "request-promise": "~4.2.0",
+    "bluebird": "~3.5.0",
     "jsdom": "~9.12.0",
     "tar-fs": "~1.15.2",
     "gunzip-maybe": "~1.4.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "test": "standard && node test.js",
+    "test": "standard && node test.js | tap-spec",
     "start": "node index.js"
   },
   "standard": {
@@ -20,6 +20,7 @@
     "get-folder-size": "~1.0.0",
     "run-series": "^1.1.4",
     "standard": "^9.0.2",
-    "tape": "~4.6.0"
+    "tape": "~4.6.0",
+    "tap-spec": "4.1.1",
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "run-series": "^1.1.4",
     "standard": "^9.0.2",
     "tape": "~4.6.0",
-    "tap-spec": "4.1.1",
+    "tap-spec": "4.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,10 +2,18 @@
   "scripts": {
     "test": "node test.js"
   },
-  "dependencies": {},
+  "dependencies": {
+    "lodash": "~4.17.4",
+    "request": "~2.81.0",
+    "async": "~2.2.0",
+    "jsdom": "~9.12.0",
+    "tar-fs": "~1.15.2",
+    "gunzip-maybe": "~1.4.0"
+  },
   "devDependencies": {
     "get-folder-size": "~1.0.0",
-    "tape": "~4.6.0",
-    "run-series": "^1.1.4"
+    "run-series": "^1.1.4",
+    "standard": "^9.0.2",
+    "tape": "~4.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,12 @@
 {
   "scripts": {
-    "test": "node test.js",
+    "test": "standard && node test.js",
     "start": "node index.js"
+  },
+  "standard": {
+    "ignore": [
+      "/packages/"
+    ]
   },
   "dependencies": {
     "request": "~2.81.0",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "request": "~2.81.0",
     "request-promise": "~4.2.0",
     "bluebird": "~3.5.0",
-    "jsdom": "~9.12.0",
     "tar-fs": "~1.15.2",
-    "gunzip-maybe": "~1.4.0"
+    "gunzip-maybe": "~1.4.0",
+    "cheerio": "~0.22.0"
   },
   "devDependencies": {
     "get-folder-size": "~1.0.0",

--- a/test.js
+++ b/test.js
@@ -68,27 +68,15 @@ function utilTestplan (callback) {
 
     series([
       cleanupPackages,
-      handleTars,
       tarballUrls,
       topPackagesMetadata,
       cleanupPackages
     ], assert.end)
 
-    function handleTars (callback) {
-      fs.readdir('./packages', function (err, files) {
-        if (err) return callback(err)
-        util.handleTars(tarballMetadata)
-          .then(function () {
-            assert.equal(files.length, 1, `has 1 file`)
-          })
-          .then(() => callback())
-      })
-    }
-
     function tarballUrls (callback) {
       util.getTarballUrls(versionMetadata)
         .then(function (result) {
-          assert.equal(tarballMetadata.toString(), result.toString(), 'tarballUrls returns expected result')
+          assert.equal(result.toString(), tarballMetadata.toString(), 'tarballUrls returns expected result')
         })
         .then(() => callback())
     }
@@ -96,7 +84,7 @@ function utilTestplan (callback) {
     function topPackagesMetadata (callback) {
       util.getTopPackagesMetadata(1)
         .then(function (result) {
-          assert.equal(versionMetadata.toString(), result.toString(), 'topPackagesMetadata returns expected result')
+          assert.equal(result.toString(), versionMetadata.toString(), 'topPackagesMetadata returns expected result')
         })
         .then(() => callback())
     }

--- a/test.js
+++ b/test.js
@@ -5,40 +5,101 @@ const series = require('run-series')
 const fs = require('fs')
 const folderSize = require('get-folder-size')
 const download = require('./')
+const del = require('del')
 
-test('download', function (t) {
-  t.plan(3)
+function cleanupPackages (callback) {
+  console.log('Clearing packages directory...')
+  del.sync(['packages/**', '!packages', '!packages/.gitignore'])
+  callback()
+}
 
-  const COUNT = parseInt(process.env.COUNT, 10) || 10
+series([
+  utilTestplan,
+  downloadTestplan
+])
 
-  series([
-    (callback) => download(COUNT, callback),
-    verifyCount,
-    verifySize,
-    verifyLodash
-  ], t.end)
+function downloadTestplan (callback) {
+  test('downloadPackages', function (t) {
+    t.plan(3)
 
-  function verifyCount (callback) {
-    fs.readdir('./packages', function (err, files) {
-      if (err) return callback(err)
-      // Filter .gitignore and other hidden files
-      files = files.filter((file) => !/^\./.test(file))
-      t.equal(files.length, COUNT, `has ${COUNT} files`)
+    const COUNT = parseInt(process.env.COUNT, 10) || 10
+
+    series([
+      cleanupPackages,
+      (callback) => download(COUNT, callback),
+      verifyCount,
+      verifySize,
+      verifyLodash,
+      cleanupPackages
+    ], t.end)
+
+    function verifyCount (callback) {
+      fs.readdir('./packages', function (err, files) {
+        if (err) return callback(err)
+        // Filter .gitignore and other hidden files
+        files = files.filter((file) => !/^\./.test(file))
+        t.equal(files.length, COUNT, `has ${COUNT} files`)
+        callback()
+      })
+    }
+
+    function verifySize (callback) {
+      folderSize('./packages', function (err, size) {
+        if (err) return callback(err)
+        t.ok(size / 1024 > 5 * COUNT, 'min 5k per package')
+        callback()
+      })
+    }
+
+    function verifyLodash (callback) {
+      const _ = require('./packages/lodash')
+      t.equal(typeof _.map, 'function', '_.map exists')
       callback()
-    })
-  }
+    }
+  })
+  callback()
+}
 
-  function verifySize (callback) {
-    folderSize('./packages', function (err, size) {
-      if (err) return callback(err)
-      t.ok(size / 1024 > 5 * COUNT, 'min 5k per package')
-      callback()
-    })
-  }
+function utilTestplan (callback) {
+  test('utils', function (assert) {
+    const util = require('./util/')
+    const versionMetadata = [ [ 'lodash', '4.17.4' ] ]
+    const tarballMetadata = [ [ 'lodash', 'http://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz' ] ]
 
-  function verifyLodash (callback) {
-    const _ = require('./packages/lodash')
-    t.equal(typeof _.map, 'function', '_.map exists')
-    callback()
-  }
-})
+    series([
+      cleanupPackages,
+      handleTars,
+      tarballUrls,
+      topPackagesMetadata,
+      cleanupPackages
+    ], assert.end)
+
+    function handleTars (callback) {
+      fs.readdir('./packages', function (err, files) {
+        if (err) return callback(err)
+        util.handleTars(tarballMetadata)
+          .then(function () {
+            assert.equal(files.length, 1, `has 1 file`)
+          })
+          .then(() => callback())
+      })
+    }
+
+    function tarballUrls (callback) {
+      util.getTarballUrls(versionMetadata)
+        .then(function (result) {
+          assert.equal(tarballMetadata.toString(), result.toString(), 'tarballUrls returns expected result')
+        })
+        .then(() => callback())
+    }
+
+    function topPackagesMetadata (callback) {
+      util.getTopPackagesMetadata(1)
+        .then(function (result) {
+          assert.equal(versionMetadata.toString(), result.toString(), 'topPackagesMetadata returns expected result')
+        })
+        .then(() => callback())
+    }
+  })
+  callback()
+}

--- a/util/handleTars.js
+++ b/util/handleTars.js
@@ -6,15 +6,20 @@ const Promise = require('bluebird')
 // Asynchronously downloads and extracts package tars into
 // appropriate folders, via a list from tarballUrls.js
 var handleTars = function (packageMetadatas) {
-  return Promise.map(packageMetadatas, (function(promise) {
-    var name = promise[0], url = promise[1]
-      return request
-        .get(url)
-        .on('error', (error) => console.log(error))
+  return Promise.map(packageMetadatas, makeRequest)
+
+  function makeRequest(metadata) {
+    return new Promise (function (resolve, reject) {
+      request
+        .get(metadata[1])
+        .on('error', (error) => { return reject ((error) => console.log(error))})
         .pipe(gunzip())
-        .pipe(tar.extract(`./packages/${name}`))
-        .on('finish', () => console.log(`* Downloaded and extracted '${name}' successfully!`))
-  }))
+        .pipe(tar.extract(`./packages/${metadata[0]}`))
+        .on('finish', function () {
+          return resolve (console.log(`* Downloaded and extracted '${metadata[0]}'' successfully!`))
+        })
+    })
+  }
 }
 
 module.exports = handleTars

--- a/util/handleTars.js
+++ b/util/handleTars.js
@@ -1,32 +1,20 @@
 const tar = require('tar-fs')
-const async = require('async')
-const request = require('request')
 const gunzip = require('gunzip-maybe')
+const request = require('request')
+const Promise = require('bluebird')
 
 // Asynchronously downloads and extracts package tars into
 // appropriate folders, via a list from tarballUrls.js
-
-var handleTars = function (list, callback) {
-  async.each(list, downloadAndExtractTar, function (error, result) {
-    if (error) console.log(error)
-    else callback(result)
-  })
-
-  function downloadAndExtractTar (packageMetadata, callback) {
-    var name = packageMetadata[0]
-    var url = packageMetadata[1]
-
-    request
-      .get(url)
-      .on('error', function (err) {
-        console.log('Oops:' + err)
-      })
-      .pipe(gunzip())
-      .pipe(tar.extract(`./packages/${name}`))
-      .on('finish', function () {
-        console.log(`* Downloaded and extracted '${name}' successfully!`)
-      })
-  }
+var handleTars = function (packageMetadatas) {
+  return Promise.map(packageMetadatas, (function(promise) {
+    var name = promise[0], url = promise[1]
+      return request
+        .get(url)
+        .on('error', (error) => console.log(error))
+        .pipe(gunzip())
+        .pipe(tar.extract(`./packages/${name}`))
+        .on('finish', () => console.log(`* Downloaded and extracted '${name}' successfully!`))
+  }))
 }
 
 module.exports = handleTars

--- a/util/handleTars.js
+++ b/util/handleTars.js
@@ -3,10 +3,10 @@ const gunzip = require('gunzip-maybe')
 const request = require('request')
 const Promise = require('bluebird')
 
-// Asynchronously downloads and extracts package tars into
-// appropriate folders, via a list from tarballUrls.js
-var handleTars = function (packageMetadatas) {
-  return Promise.map(packageMetadatas, makeRequest)
+// Asynchronously downloads and extracts package tars into appropriate
+// folders, via an array of package names and tarball URLs
+var handleTars = function (packagesMetadata) {
+  return Promise.map(packagesMetadata, makeRequest)
 
   function makeRequest (metadata) {
     return new Promise(function (resolve, reject) {
@@ -16,6 +16,7 @@ var handleTars = function (packageMetadatas) {
         .on('error', (error) => { return reject(console.log(error)) })
         .pipe(tar.extract(`./packages/${metadata[0]}`, {
           map: function (header) {
+            // remove the unnecessary 'package/' parent directory from path
             header.name = transformPath(header.name)
             return header
           }

--- a/util/handleTars.js
+++ b/util/handleTars.js
@@ -14,10 +14,22 @@ var handleTars = function (packageMetadatas) {
         .get(metadata[1])
         .on('error', (error) => { return reject ((error) => console.log(error))})
         .pipe(gunzip())
-        .pipe(tar.extract(`./packages/${metadata[0]}`))
+        .on('error', (error) => { return reject ((error) => console.log(error))})
+        .pipe(tar.extract(`./packages/${metadata[0]}`, {
+          map: function(header) {
+            header.name = transformPath(header.name)
+            return header
+          }
+        }))
+        .on('error', (error) => { return reject ((error) => console.log(error))})
         .on('finish', function () {
-          return resolve (console.log(`* Downloaded and extracted '${metadata[0]}'' successfully!`))
+          return resolve (console.log(`* Downloaded and extracted '${metadata[0]}' successfully!`))
         })
+
+      function transformPath (path) {
+        var original = path.split('/'), updated = original.splice(0,1)
+        return original.join('/')
+      }
     })
   }
 }

--- a/util/handleTars.js
+++ b/util/handleTars.js
@@ -1,0 +1,32 @@
+const tar = require('tar-fs')
+const async = require('async')
+const request = require('request')
+const gunzip = require('gunzip-maybe')
+
+// Asynchronously downloads and extracts package tars into
+// appropriate folders, via a list from tarballUrls.js
+
+var handleTars = function (list, callback) {
+  async.each(list, downloadAndExtractTar, function (error, result) {
+    if (error) console.log(error)
+    else callback(result)
+  })
+
+  function downloadAndExtractTar (packageMetadata, callback) {
+    var name = packageMetadata[0]
+    var url = packageMetadata[1]
+
+    request
+      .get(url)
+      .on('error', function (err) {
+        console.log('Oops:' + err)
+      })
+      .pipe(gunzip())
+      .pipe(tar.extract(`./packages/${name}`))
+      .on('finish', function () {
+        console.log(`* Downloaded and extracted '${name}' successfully!`)
+      })
+  }
+}
+
+module.exports = handleTars

--- a/util/handleTars.js
+++ b/util/handleTars.js
@@ -5,6 +5,8 @@ const gunzip = require('gunzip-maybe')
 const request = require('request')
 const Promise = require('bluebird')
 
+module.exports = handleTars
+
 // Asynchronously downloads and extracts package tars into appropriate
 // folders, via an array of package names and tarball URLs
 function handleTars (packagesMetadata) {
@@ -37,5 +39,3 @@ function handleTars (packagesMetadata) {
     })
   }
 }
-
-module.exports = handleTars

--- a/util/handleTars.js
+++ b/util/handleTars.js
@@ -12,7 +12,8 @@ var handleTars = function (packagesMetadata) {
 
   function makeRequest (metadata) {
     return new Promise(function (resolve, reject) {
-      request.get(metadata[1])
+      request
+        .get(metadata[1])
         .on('error', (error) => { return reject(console.log(error)) })
         .pipe(gunzip())
         .on('error', (error) => { return reject(console.log(error)) })

--- a/util/handleTars.js
+++ b/util/handleTars.js
@@ -10,9 +10,7 @@ module.exports = handleTars
 // Asynchronously downloads and extracts package tars into appropriate
 // folders, via an array of package names and tarball URLs
 function handleTars (packagesMetadata) {
-  return Promise.map(packagesMetadata, makeRequest)
-
-  function makeRequest (metadata) {
+  return Promise.map(packagesMetadata, function (metadata) {
     return new Promise(function (resolve, reject) {
       request
         .get(metadata[1])
@@ -37,5 +35,5 @@ function handleTars (packagesMetadata) {
         return splitPath.join('/')
       }
     })
-  }
+  })
 }

--- a/util/handleTars.js
+++ b/util/handleTars.js
@@ -8,27 +8,27 @@ const Promise = require('bluebird')
 var handleTars = function (packageMetadatas) {
   return Promise.map(packageMetadatas, makeRequest)
 
-  function makeRequest(metadata) {
-    return new Promise (function (resolve, reject) {
-      request
-        .get(metadata[1])
-        .on('error', (error) => { return reject ((error) => console.log(error))})
+  function makeRequest (metadata) {
+    return new Promise(function (resolve, reject) {
+      request.get(metadata[1])
+        .on('error', (error) => { return reject(console.log(error)) })
         .pipe(gunzip())
-        .on('error', (error) => { return reject ((error) => console.log(error))})
+        .on('error', (error) => { return reject(console.log(error)) })
         .pipe(tar.extract(`./packages/${metadata[0]}`, {
-          map: function(header) {
+          map: function (header) {
             header.name = transformPath(header.name)
             return header
           }
         }))
-        .on('error', (error) => { return reject ((error) => console.log(error))})
+        .on('error', (error) => { return reject(console.log(error)) })
         .on('finish', function () {
-          return resolve (console.log(`* Downloaded and extracted '${metadata[0]}' successfully!`))
+          return resolve(console.log(`* Downloaded and extracted '${metadata[0]}' successfully!`))
         })
 
       function transformPath (path) {
-        var original = path.split('/'), updated = original.splice(0,1)
-        return original.join('/')
+        var splitPath = path.split('/')
+        splitPath.splice(0, 1)
+        return splitPath.join('/')
       }
     })
   }

--- a/util/handleTars.js
+++ b/util/handleTars.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const tar = require('tar-fs')
 const gunzip = require('gunzip-maybe')
 const request = require('request')

--- a/util/handleTars.js
+++ b/util/handleTars.js
@@ -7,7 +7,7 @@ const Promise = require('bluebird')
 
 // Asynchronously downloads and extracts package tars into appropriate
 // folders, via an array of package names and tarball URLs
-var handleTars = function (packagesMetadata) {
+function handleTars (packagesMetadata) {
   return Promise.map(packagesMetadata, makeRequest)
 
   function makeRequest (metadata) {

--- a/util/index.js
+++ b/util/index.js
@@ -1,0 +1,3 @@
+exports.getTopPackagesMetadata = require('./topPackagesMetadata')
+exports.getTarballUrls = require('./tarballUrls')
+exports.handleTars = require('./handleTars')

--- a/util/tarballUrls.js
+++ b/util/tarballUrls.js
@@ -7,25 +7,26 @@ var getTarballUrls = function (packageMap) {
   var constructedUris = constructUris(packageMap)
   var names = Array.from(packageMap.keys())
 
-  return Promise.map(constructedUris, function(uri) {
+  return Promise.map(constructedUris, function (uri) {
     return request({uri: uri, json: true})
       // return the tarball url
       .then(function (response) {
         return response.dist.tarball
       })
-    })
+      .catch((error) => console.log(error))
+  })
   // then zip results with package names
-  .then(function(results) {
+  .then(function (results) {
     return names.map(function (error, item) {
       return [names[item], results[item]]
     })
   })
+  .catch((error) => console.log(error))
 
   function constructUris (packageMap) {
     var uris = []
     for (var item of packageMap) {
-      var name = item[0], version = item[1]
-      uris.push(`https://registry.npmjs.org/${name}/${version}`)
+      uris.push(`https://registry.npmjs.org/${item[0]}/${item[1]}`)
     }
     return uris
   }

--- a/util/tarballUrls.js
+++ b/util/tarballUrls.js
@@ -4,6 +4,8 @@ const request = require('request-promise')
 const Promise = require('bluebird')
 const REGISTRY_URI = process.env.REGISTRY_URI || 'https://registry.npmjs.org/'
 
+module.exports = getTarballUrls
+
 // Grabs package registry metadata and returns an array of package names and their
 // tarball URLs, via an array of package names and versions
 function getTarballUrls (packagesMetadata) {
@@ -27,5 +29,3 @@ function getTarballUrls (packagesMetadata) {
   })
   .catch((error) => console.log(error))
 }
-
-module.exports = getTarballUrls

--- a/util/tarballUrls.js
+++ b/util/tarballUrls.js
@@ -17,8 +17,8 @@ var getTarballUrls = function (packageMap) {
   })
   // then zip results with package names
   .then(function (results) {
-    return names.map(function (error, item) {
-      return [names[item], results[item]]
+    return names.map(function (name, uri) {
+      return [name, results[uri]]
     })
   })
   .catch((error) => console.log(error))

--- a/util/tarballUrls.js
+++ b/util/tarballUrls.js
@@ -9,21 +9,23 @@ var getTarballUrls = function (packageMap) {
 
   return Promise.map(constructedUris, function(uri) {
     return request({uri: uri, json: true})
-      .then(function (response) { // return the tarball url
+      // return the tarball url
+      .then(function (response) {
         return response.dist.tarball
       })
     })
-    .then(function(results) { // add package names to results
-      return names.map(function (error, item) {
-        return [names[item], results[item]]
-      })
+  // then zip results with package names
+  .then(function(results) {
+    return names.map(function (error, item) {
+      return [names[item], results[item]]
     })
+  })
 
   function constructUris (packageMap) {
     var uris = []
     for (var item of packageMap) {
       var name = item[0], version = item[1]
-      uris.push('https://registry.npmjs.org/' + name + '/' + version)
+      uris.push(`https://registry.npmjs.org/${name}/${version}`)
     }
     return uris
   }

--- a/util/tarballUrls.js
+++ b/util/tarballUrls.js
@@ -14,7 +14,7 @@ function getTarballUrls (packagesMetadata) {
   })
 
   return Promise.map(constructedUris, function (uri) {
-    return request({uri: uri, json: true})
+    return request({uri: uri, timeout: 5000, json: true})
       // return the tarball url
       .then(function (response) {
         return response.dist.tarball

--- a/util/tarballUrls.js
+++ b/util/tarballUrls.js
@@ -1,23 +1,23 @@
-const request = require('request')
-const async = require('async')
+const request = require('request-promise')
+const Promise = require('bluebird')
 
 // Grabs and returns an array of package names and their
 // tarball URLs, with a Map provided by topPackagesList.js
-
-var getTarballUrls = function (packageMap, callback) {
+var getTarballUrls = function (packageMap) {
   var constructedUris = constructUris(packageMap)
   var names = Array.from(packageMap.keys())
 
-  async.map(constructedUris, makeRequest, function (error, results) {
-    if (error) {
-      console.log(error)
-    } else {
-      var zippedResults = names.map(function (error, item) {
+  return Promise.map(constructedUris, function(uri) {
+    return request({uri: uri, json: true})
+      .then(function (response) { // return the tarball url
+        return response.dist.tarball
+      })
+    })
+    .then(function(results) { // add package names to results
+      return names.map(function (error, item) {
         return [names[item], results[item]]
       })
-      callback(zippedResults)
-    }
-  })
+    })
 
   function constructUris (packageMap) {
     var uris = []
@@ -26,16 +26,6 @@ var getTarballUrls = function (packageMap, callback) {
       uris.push('https://registry.npmjs.org/' + name + '/' + version)
     }
     return uris
-  }
-
-  function makeRequest (uri, callback) {
-    request({uri: uri, json: true}, function (error, response, body) {
-      if (error) {
-        console.log(error)
-      } else {
-        callback(null, body.dist.tarball)
-      }
-    })
   }
 }
 

--- a/util/tarballUrls.js
+++ b/util/tarballUrls.js
@@ -6,7 +6,7 @@ const REGISTRY_URI = process.env.REGISTRY_URI || 'https://registry.npmjs.org/'
 
 // Grabs package registry metadata and returns an array of package names and their
 // tarball URLs, via an array of package names and versions
-var getTarballUrls = function (packagesMetadata) {
+function getTarballUrls (packagesMetadata) {
   var constructedUris = packagesMetadata.map(function (metadata) {
     return REGISTRY_URI + `${metadata[0]}/${metadata[1]}`
   })

--- a/util/tarballUrls.js
+++ b/util/tarballUrls.js
@@ -1,0 +1,42 @@
+const request = require('request')
+const async = require('async')
+
+// Grabs and returns an array of package names and their
+// tarball URLs, with a Map provided by topPackagesList.js
+
+var getTarballUrls = function (packageMap, callback) {
+  var constructedUris = constructUris(packageMap)
+  var names = Array.from(packageMap.keys())
+
+  async.map(constructedUris, makeRequest, function (error, results) {
+    if (error) {
+      console.log(error)
+    } else {
+      var zippedResults = names.map(function (error, item) {
+        return [names[item], results[item]]
+      })
+      callback(zippedResults)
+    }
+  })
+
+  function constructUris (packageMap) {
+    var uris = []
+    for (var item of packageMap) {
+      var name = item[0], version = item[1]
+      uris.push('https://registry.npmjs.org/' + name + '/' + version)
+    }
+    return uris
+  }
+
+  function makeRequest (uri, callback) {
+    request({uri: uri, json: true}, function (error, response, body) {
+      if (error) {
+        console.log(error)
+      } else {
+        callback(null, body.dist.tarball)
+      }
+    })
+  }
+}
+
+module.exports = getTarballUrls

--- a/util/tarballUrls.js
+++ b/util/tarballUrls.js
@@ -2,12 +2,13 @@
 
 const request = require('request-promise')
 const Promise = require('bluebird')
+const REGISTRY_URI = process.env.REGISTRY_URI || 'https://registry.npmjs.org/'
 
 // Grabs package registry metadata and returns an array of package names and their
 // tarball URLs, via an array of package names and versions
 var getTarballUrls = function (packagesMetadata) {
   var constructedUris = packagesMetadata.map(function (metadata) {
-    return `https://registry.npmjs.org/${metadata[0]}/${metadata[1]}`
+    return REGISTRY_URI + `${metadata[0]}/${metadata[1]}`
   })
 
   return Promise.map(constructedUris, function (uri) {

--- a/util/tarballUrls.js
+++ b/util/tarballUrls.js
@@ -1,11 +1,12 @@
 const request = require('request-promise')
 const Promise = require('bluebird')
 
-// Grabs and returns an array of package names and their
-// tarball URLs, with a Map provided by topPackagesList.js
-var getTarballUrls = function (packageMap) {
-  var constructedUris = constructUris(packageMap)
-  var names = Array.from(packageMap.keys())
+// Grabs package registry metadata and returns an array of package names and their
+// tarball URLs, via an array of package names and versions
+var getTarballUrls = function (packagesMetadata) {
+  var constructedUris = packagesMetadata.map(function (metadata) {
+    return `https://registry.npmjs.org/${metadata[0]}/${metadata[1]}`
+  })
 
   return Promise.map(constructedUris, function (uri) {
     return request({uri: uri, json: true})
@@ -17,19 +18,11 @@ var getTarballUrls = function (packageMap) {
   })
   // then zip results with package names
   .then(function (results) {
-    return names.map(function (name, uri) {
-      return [name, results[uri]]
+    return packagesMetadata.map(function (name, uri) {
+      return [name[0], results[uri]]
     })
   })
   .catch((error) => console.log(error))
-
-  function constructUris (packageMap) {
-    var uris = []
-    for (var item of packageMap) {
-      uris.push(`https://registry.npmjs.org/${item[0]}/${item[1]}`)
-    }
-    return uris
-  }
 }
 
 module.exports = getTarballUrls

--- a/util/tarballUrls.js
+++ b/util/tarballUrls.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const request = require('request-promise')
 const Promise = require('bluebird')
 

--- a/util/topPackagesMetadata.js
+++ b/util/topPackagesMetadata.js
@@ -1,41 +1,43 @@
-const jsdom = require('jsdom')
+const request = require('request-promise')
+const cheerio = require('cheerio')
 const Promise = require('bluebird')
 
-// Grabs /depended HTML, parses pertinent elements and
-// returns them in a Map.
-
+// Grabs /depended HTML, parses pertinent elements, and
+// returns those elements in a Map.
 var getTopPackagesMetadata = function (count) {
   return new Promise (function (resolve, reject) {
-    jsdom.env({
-      url: 'https://www.npmjs.com/browse/depended',
-      done: function (error, window) {
-        if (error) {
-          reject(console.log(error))
-        } else {
-          document = window.document
-          resolve(extractPackagesMetadata(count))
-        }
+    var options = {
+      uri: 'https://www.npmjs.com/browse/depended',
+      transform: function (body) {
+        return cheerio.load(body)
       }
-    })
+    }
+
+    return request(options)
+      .then(function ($) {
+        resolve(extractPackagesMetadata(count, $))
+      })
+      .catch(function (error) {
+        reject(error)
+      })
   })
 
-  function extractPackagesMetadata (count) {
-    var packageNames = parseElements('name', count)
-    var packageVersions = parseElements('version', count)
+  function extractPackagesMetadata (count, $) {
+    var packageNames = parseElements('name', count, $)
+    var packageVersions = parseElements('version', count, $)
 
     var list = new Map() // use Map instead of Object to preserve order
-
     for (var i = 0; i < packageNames.length; i++) {
       list.set(packageNames[i], packageVersions[i])
     }
     return list
   }
 
-  function parseElements (element, count) {
-    var elements = document.getElementsByClassName(element)
-    return Array.from(elements)
-      .slice(0, (count || 10))
-      .map(item => item.text)
+  function parseElements (element, count, $) {
+    var elements = $(`.${element}`).map(function() {
+      return $(this).text()
+    }).slice(0, (count).get()
+    return elements
   }
 }
 

--- a/util/topPackagesMetadata.js
+++ b/util/topPackagesMetadata.js
@@ -8,36 +8,26 @@ var getTopPackagesMetadata = function (count) {
   return new Promise (function (resolve, reject) {
     var options = {
       uri: 'https://www.npmjs.com/browse/depended',
-      transform: function (body) {
-        return cheerio.load(body)
-      }
+      transform: (body) => { return cheerio.load(body)}
     }
 
     return request(options)
-      .then(function ($) {
-        resolve(extractPackagesMetadata(count, $))
-      })
-      .catch(function (error) {
-        reject(error)
-      })
+      .then(($) => resolve(extractPackagesMetadata(count, $)))
+      .catch((error) => reject(error))
   })
 
   function extractPackagesMetadata (count, $) {
-    var packageNames = parseElements('name', count, $)
-    var packageVersions = parseElements('version', count, $)
-
-    var list = new Map() // use Map instead of Object to preserve order
-    for (var i = 0; i < packageNames.length; i++) {
-      list.set(packageNames[i], packageVersions[i])
-    }
-    return list
+    var names = parseElements('name', count, $)
+    var versions = parseElements('version', count, $)
+    var metadata = names.map((name, version) => { return [name, versions[version]] })
+    return new Map(metadata) // use Map instead of Object to preserve order
   }
 
   function parseElements (element, count, $) {
-    var elements = $(`.${element}`).map(function() {
-      return $(this).text()
-    }).slice(0, (count).get()
-    return elements
+    return $(`.${element}`)
+      .map(function() { return $(this).text() })
+      .slice(0, count)
+      .get()
   }
 }
 

--- a/util/topPackagesMetadata.js
+++ b/util/topPackagesMetadata.js
@@ -5,6 +5,8 @@ const cheerio = require('cheerio')
 const Promise = require('bluebird')
 const DEPENDED_URI = process.env.DEPENDED_URI || 'https://www.npmjs.com/browse/depended'
 
+module.exports = getTopPackagesMetadata
+
 // Grabs /depended HTML, parses pertinent elements, and
 // returns the text of those elements in an array
 function getTopPackagesMetadata (count) {
@@ -33,5 +35,3 @@ function getTopPackagesMetadata (count) {
       .get()
   }
 }
-
-module.exports = getTopPackagesMetadata

--- a/util/topPackagesMetadata.js
+++ b/util/topPackagesMetadata.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const request = require('request-promise')
 const cheerio = require('cheerio')
 const Promise = require('bluebird')

--- a/util/topPackagesMetadata.js
+++ b/util/topPackagesMetadata.js
@@ -3,7 +3,7 @@ const cheerio = require('cheerio')
 const Promise = require('bluebird')
 
 // Grabs /depended HTML, parses pertinent elements, and
-// returns those elements in a Map.
+// returns the text of those elements in an array
 var getTopPackagesMetadata = function (count) {
   return new Promise(function (resolve, reject) {
     var options = {
@@ -19,8 +19,7 @@ var getTopPackagesMetadata = function (count) {
   function extractPackagesMetadata (count, $) {
     var names = parseElements('name', count, $)
     var versions = parseElements('version', count, $)
-    var metadata = names.map((name, version) => { return [name, versions[version]] })
-    return new Map(metadata) // use Map instead of Object to preserve order
+    return names.map((name, version) => { return [name, versions[version]] })
   }
 
   function parseElements (element, count, $) {

--- a/util/topPackagesMetadata.js
+++ b/util/topPackagesMetadata.js
@@ -3,17 +3,19 @@
 const request = require('request-promise')
 const cheerio = require('cheerio')
 const Promise = require('bluebird')
+const DEPENDED_URI = process.env.DEPENDED_URI || 'https://www.npmjs.com/browse/depended'
 
 // Grabs /depended HTML, parses pertinent elements, and
 // returns the text of those elements in an array
 var getTopPackagesMetadata = function (count) {
   return new Promise(function (resolve, reject) {
     var options = {
-      uri: 'https://www.npmjs.com/browse/depended',
+      uri: DEPENDED_URI,
       transform: (body) => { return cheerio.load(body) }
     }
 
-    return request(options)
+    return request
+      .get(options)
       .then(($) => resolve(extractPackagesMetadata(count, $)))
       .catch((error) => reject(error))
   })

--- a/util/topPackagesMetadata.js
+++ b/util/topPackagesMetadata.js
@@ -13,6 +13,7 @@ function getTopPackagesMetadata (count) {
   return new Promise(function (resolve, reject) {
     var options = {
       uri: DEPENDED_URI,
+      timeout: 5000,
       transform: (body) => { return cheerio.load(body) }
     }
 

--- a/util/topPackagesMetadata.js
+++ b/util/topPackagesMetadata.js
@@ -7,7 +7,7 @@ const DEPENDED_URI = process.env.DEPENDED_URI || 'https://www.npmjs.com/browse/d
 
 // Grabs /depended HTML, parses pertinent elements, and
 // returns the text of those elements in an array
-var getTopPackagesMetadata = function (count) {
+function getTopPackagesMetadata (count) {
   return new Promise(function (resolve, reject) {
     var options = {
       uri: DEPENDED_URI,

--- a/util/topPackagesMetadata.js
+++ b/util/topPackagesMetadata.js
@@ -1,0 +1,38 @@
+const jsdom = require('jsdom')
+
+// Grabs /depended HTML, parses pertinent elements and
+// returns them in a Map.
+
+var getTopPackagesMetadata = function (count, callback) {
+  jsdom.env({
+    url: 'https://www.npmjs.com/browse/depended',
+    done: function (error, window) {
+      if (error) {
+        console.log(error)
+      } else {
+        document = window.document
+        callback(extractPackagesMetadata(count))
+      }
+    }
+  })
+
+  function extractPackagesMetadata (count) {
+    var packageNames = parseElements('name', count)
+    var packageVersions = parseElements('version', count)
+    var list = new Map() // use Map instead of Object to preserve order
+
+    for (var i = 0; i < packageNames.length; i++) {
+      list.set(packageNames[i], packageVersions[i])
+    }
+    return list
+  }
+
+  function parseElements (element, count) {
+    var elements = document.getElementsByClassName(element)
+    return Array.from(elements)
+                .slice(0, (count || 10))
+                .map(item => item.text)
+  }
+}
+
+module.exports = getTopPackagesMetadata

--- a/util/topPackagesMetadata.js
+++ b/util/topPackagesMetadata.js
@@ -5,10 +5,10 @@ const Promise = require('bluebird')
 // Grabs /depended HTML, parses pertinent elements, and
 // returns those elements in a Map.
 var getTopPackagesMetadata = function (count) {
-  return new Promise (function (resolve, reject) {
+  return new Promise(function (resolve, reject) {
     var options = {
       uri: 'https://www.npmjs.com/browse/depended',
-      transform: (body) => { return cheerio.load(body)}
+      transform: (body) => { return cheerio.load(body) }
     }
 
     return request(options)
@@ -25,7 +25,7 @@ var getTopPackagesMetadata = function (count) {
 
   function parseElements (element, count, $) {
     return $(`.${element}`)
-      .map(function() { return $(this).text() })
+      .map(function () { return $(this).text() })
       .slice(0, count)
       .get()
   }

--- a/util/topPackagesMetadata.js
+++ b/util/topPackagesMetadata.js
@@ -1,24 +1,28 @@
 const jsdom = require('jsdom')
+const Promise = require('bluebird')
 
 // Grabs /depended HTML, parses pertinent elements and
 // returns them in a Map.
 
-var getTopPackagesMetadata = function (count, callback) {
-  jsdom.env({
-    url: 'https://www.npmjs.com/browse/depended',
-    done: function (error, window) {
-      if (error) {
-        console.log(error)
-      } else {
-        document = window.document
-        callback(extractPackagesMetadata(count))
+var getTopPackagesMetadata = function (count) {
+  return new Promise (function (resolve, reject) {
+    jsdom.env({
+      url: 'https://www.npmjs.com/browse/depended',
+      done: function (error, window) {
+        if (error) {
+          reject(console.log(error))
+        } else {
+          document = window.document
+          resolve(extractPackagesMetadata(count))
+        }
       }
-    }
+    })
   })
 
   function extractPackagesMetadata (count) {
     var packageNames = parseElements('name', count)
     var packageVersions = parseElements('version', count)
+
     var list = new Map() // use Map instead of Object to preserve order
 
     for (var i = 0; i < packageNames.length; i++) {
@@ -30,8 +34,8 @@ var getTopPackagesMetadata = function (count, callback) {
   function parseElements (element, count) {
     var elements = document.getElementsByClassName(element)
     return Array.from(elements)
-                .slice(0, (count || 10))
-                .map(item => item.text)
+      .slice(0, (count || 10))
+      .map(item => item.text)
   }
 }
 


### PR DESCRIPTION
This change implements an MVP solution to the homework assignment.

## Implementation
At a top level, this solution accomplishes the goals as stated in the assignment primarily with a function in `./index.js`, supplemented by a handful of scripts in the new `./util` folder. I tried to keep the functionality of this in line with the stated goal as much as possible, so no deletions of source material are present.
#
In a series of promises, these new scripts:
1. parse the `name` and `version` elements of packages on https://www.npmjs.com/browse/depended
    * there doesn't appear to be an API to grab these from, and it seemed overkill (and sort of insane, given assignment context) to graph and calculate these results from a snapshot of the entire npm registry

2. use the elements from (1) to grab the URL for the tarball of the package
    * this could've been achieved with much less code if it was assumed that the npm dist would never change, but because it's dangerous to assume any API won't change, this grabs the URL from npm every time

3. download and extract package tarballs from (2) on a stream
#
Two new environment variables are available: 
`DEPENDED_URI`: a toe-dip into test stubbing waters, this can be set to mimic the source URI
`REGISTRY_URI`: set if you have your own npm registry

## Testing
The original tests have not been modified. Where applicable considering redundancy, new tests are added to cover additions. Other changes include adding [Standardjs](https://standardjs.com/) and [tap-spec](https://github.com/scottcorgan/tap-spec) to the test script, and a cleanup function to make sure the `./packages` folder is fresh for every test run.

## Out-of-scope / 'TODO's
I wanted to do a lot more with this, but for the sake of time and 'MVP', I kept scope small. Some things I would implement given more time:
* Mocking and stubbing the test suite so it doesn't need to rely on live external services
* Extend coverage of tests for failure scenarios
* Package versioning check, so the script can skip/terminate early if a package at its current version already exists in the filesystem
* Better error handling, mostly around when a single package fails to download